### PR TITLE
use "..." to allow whitespaces in app_file

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -21,7 +21,7 @@ echo "MAESTRO INSTALLED - Check Version"
 maestro -v
 
 # Run Maestro Cloud
-xcrun simctl install booted $app_file
+xcrun simctl install booted "$app_file"
 xcrun simctl io booted recordVideo --codec=h264 -f $BITRISE_DEPLOY_DIR/ui_tests.mp4 &
 maestro test $workspace/ --format junit --output $BITRISE_DEPLOY_DIR/test_report.xml $additional_params || true
 killall -SIGINT simctl


### PR DESCRIPTION
The change ensures that the `$app_file` variable is properly quoted when passed to the `xcrun simctl install` command to handle file paths with spaces or special characters.

## Repro Steps

1. Use the *.app path including a whitespace (e.g. `Build/Product/Test App.app`)

## Expected

✅  The path is recognized. (e.g. `Build/Product/Test App.app`)

## As-Is

🚫  The path is only passed before the whitespace. (e.g. `Build/Product/Test`)